### PR TITLE
Fix typo in watchFile function

### DIFF
--- a/overwolf.d.ts
+++ b/overwolf.d.ts
@@ -277,7 +277,7 @@ declare namespace overwolf.io {
    */
   function stopFileListener(id: string): void;
 
-  function WatchFile(
+  function watchFile(
     filePath: string,
     callback: CallbackFunction<WatchedFileChanged>
   ): void;


### PR DESCRIPTION
Function is called `watchFile` and not `WatchFile` : https://overwolf.github.io/api/io#watchfilefilepath-callback